### PR TITLE
remove pkg-resources from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ httplib2==0.15.0
 jmespath==0.9.4
 numpy==1.18.0
 pandas==0.23.0
-pkg-resources==0.0.0
 pyasn1==0.4.8
 pycparser==2.19
 python-dateutil==2.8.1


### PR DESCRIPTION
Fixes:
```
ERROR: Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 12)) (from versions: none)
ERROR: No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 12))
```

Background: https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command/40167445#40167445
