### PR TITLE
Update nda_aws_token_generator.py to handle hashing passwords using both SHA1 and SHA256 methods.

### DIFF
--- a/src/nda_aws_token_generator.py
+++ b/src/nda_aws_token_generator.py
@@ -2,7 +2,7 @@
 
 ## NDA AWS Token Generator
 ## Author: NIMH Data Archives
-##         http://nda.nih.gov
+##         http://ndar.nih.gov
 ## License: MIT
 ##          https://opensource.org/licenses/MIT
 
@@ -24,20 +24,36 @@ class NDATokenGenerator(object):
         'data': 'http://gov/nih/ndar/ws/datamanager/server/bean/jaxb'
     }
 
-    def __init__(self, url='https://nda.nih.gov/DataManager/dataManager'):
+    __password_encoding = 'SHA-256'
+
+    def __init__(self, url):
         assert url is not None
         self.url = url
         logging.debug('constructed with url %s' % url)
 
     def generate_token(self, username, password):
         logging.info('request to generate AWS token')
-        encoded_password = self.__encode_password(password)
-        request_xml = self.__construct_request_xml(username, encoded_password)
-        return self.__make_request(request_xml)
+        try:
+            encoded_password = self.__encode_password(password)
+            request_xml = self.__construct_request_xml(username, encoded_password)
+            return self.__make_request(request_xml)
+        except Exception:
+            if self.__password_encoding == 'SHA-256':
+                self.__password_encoding = 'SHA-1'
+            else:
+                raise Exception
+            encoded_password = self.__encode_password(password)
+            request_xml = self.__construct_request_xml(username, encoded_password)
+            return self.__make_request(request_xml)
 
     def __encode_password(self, password):
         logging.debug('encoding password')
-        hasher = hashlib.sha1()
+
+        if self.__password_encoding == 'SHA-256':
+            hasher = hashlib.sha256()
+        elif self.__password_encoding == "SHA-1":
+            hasher = hashlib.sha1()
+
         hasher.update(password.encode('utf-8'))
         digest_bytes = hasher.digest()
         byte_string = binascii.hexlify(digest_bytes)
@@ -81,6 +97,7 @@ class NDATokenGenerator(object):
         request = urllib_request.Request(self.url, data=request_message, headers=headers)
         logging.debug(request)
         response = urllib_request.urlopen(request)
+
         return self.__parse_response(response.read())
 
     def __parse_response(self, response):
@@ -88,6 +105,7 @@ class NDATokenGenerator(object):
         tree = etree.fromstring(response)
 
         error = tree.find('.//errorMessage')
+
         if error is not None:
             error_msg = error.text
             logging.error('response had error message: %s' % error_msg)


### PR DESCRIPTION
NDA has moved to using SHA256 encryption on passwords, and clients of the DataManager SOAP service will need to support both SHA1 and SHA256 encryption while passwords get updated.

This may resolve the recent issue reported by @kimberlylray here: https://github.com/DCAN-Labs/nda-abcd-s3-downloader/issues/14

**Noting here that access to DataManager for single-use FederationUser tokens is deprecated and will be going away in the very near future. https://mailchi.mp/mail/new-nda-download-manager-tool-now-available?e=2f3deecfc4**